### PR TITLE
add __cuda as run dependency for GPU build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - pytorch =*={{ torch_proc_type }}*      # [cuda_compiler_version != "None"]
   run:
     - python
+    - __cuda  # [cuda_compiler_version != "None"]
   run_constrained:
     # additional run constraint to the one from the (version-only) run_export;
     # constraining the CPU builds to CPU pytorch isn't 100% necessary, but cleaner

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 776b08336a524fb90867365af52307870cc7dc95c3d7b5cf2577f0dcdb647e36
 
 build:
-  number: 4
+  number: 5
   # no pytorch on windows in conda-forge, see
   # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/32
   skip: true  # [win]


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Setting cude requirement in order to prevent GPU build from behind selected by conda in a non GPU environment.
https://github.com/conda-forge/fairscale-feedstock/issues/17
